### PR TITLE
Fix and check sequence from API

### DIFF
--- a/module/transcript.py
+++ b/module/transcript.py
@@ -12,6 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import requests
+import re
 
 
 class CodingSequence:
@@ -35,6 +36,14 @@ class CodingSequence:
             response = requests.post(url, json=body)
             seq = response.text
             if response.status_code == requests.codes.ok:
+                matches = re.match(r'^([CTGAN]+)<', seq)
+                if matches:
+                    print(f"Remove weird html part at the end of {self.feature_name}")
+                    print(f"[{seq}]")
+                    seq = matches[1]
+                if not re.match(r'^[CGTAN]+$', seq):
+                    print(f"Incorrect CDS sequence: [{seq}]")
+                    return False
                 self.sequence = seq
             else:
                 return False


### PR DESCRIPTION
The Apollo API might add a weird html string after the sequence. This is a quick fix to remove that part, and check that the sequence used is only made up of nucleotides.